### PR TITLE
Edit buildtool.py to prevent write lines again

### DIFF
--- a/buildtool.py
+++ b/buildtool.py
@@ -65,6 +65,9 @@ for sample_file in FILES.keys():
                         newline = re.sub(key, get_env_value(ENV, key[1:-1]),\
                             line)
                         line = newline
+                    else:
+                        newline = " "
+                        line = " "
             output_lines.append(newline)
 
     with open(FILES.get(sample_file), 'w') as output:


### PR DESCRIPTION
Edit buildtool.py to prevent write lines again that actually had written in the last loop rutin in 'newline' and 'line' vars.